### PR TITLE
chore: config all-contributors bot

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,15 @@
+{
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "contributorsPerLine": 7,
+  "contributorsSortAlphabetically": false,
+  "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
+  "skipCi": true,
+  "contributors": [],
+  "projectName": "stem-diverse-tv-cms",
+  "projectOwner": "anitab-org",
+  "repoType": "github",
+  "repoHost": "https://github.com"
+}

--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ To get the frontend running locally:
 
 Please read our [Contributing Guidelines](.github/CONTRIBUTING_GUIDELINES.md), [Code of Conduct](.github/CODE_OF_CONDUCT.md) and [Reporting Guidelines](.github/REPORTING_GUIDLINES.md) thoroughly.
 
+### Contributors
+
+Thanks goes to these people ([emoji key](https://github.com/all-contributors/all-contributors#emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification.
+Contributions of any kind welcome!
+
 ## Branches
 
 - master: This contains the latest code. All the contributing PRs must be sent to this branch.


### PR DESCRIPTION
### Description

- Create all-contributors configuration file.
- Add contributors section to README.

Fixes #62 

### Type of Change:

- Code
- Documentation

### How Has This Been Tested?

I followed this example which I used before in all the other active repositories: https://github.com/anitab-org/mentorship-android/pull/1114/files

After merge you can run the command on any comment, can be this PR or on an issue.

```
@all-contributors please add @annabauza for code, maintenance, test, doc and design
```
The documentation shows the available tags. the bot will then create a PR to add you to JSON config and README.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged

